### PR TITLE
Added a Todo List Demo

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,8 +20,18 @@ let package = Package(
         // 🧱 Plot a DSL for writing type-safe HTML
         // - Note: the fork at btoms20 is an Async/Await version of Plot
         .package(url: "https://github.com/btoms20/Plot.git", branch: "master"),
-        // Vapor (for the Demo)
+        
+        // The following dependencies are for the locally hosted Demo's
+        
+        // Vapor
         .package(url: "https://github.com/vapor/vapor.git", from: "4.91.1"),
+        
+        // The following dependencies are only for the TODO List Demo
+        
+        // 🗄 An ORM for SQL and NoSQL databases
+        .package(url: "https://github.com/vapor/fluent.git", from: "4.8.0"),
+        // 🐘 Fluent driver for Postgres.
+        .package(url: "https://github.com/vapor/fluent-postgres-driver.git", from: "2.7.2"),
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.
@@ -41,6 +51,15 @@ let package = Package(
             dependencies: [
                 .target(name: "AsyncPlotTabler"),
                 .product(name: "Vapor", package: "vapor"),
+            ]
+        ),
+        .executableTarget(
+            name: "Todo",
+            dependencies: [
+                .target(name: "AsyncPlotTabler"),
+                .product(name: "Vapor", package: "vapor"),
+                .product(name: "Fluent", package: "Fluent"),
+                .product(name: "FluentPostgresDriver", package: "fluent-postgres-driver"),
             ]
         ),
     ]

--- a/README.md
+++ b/README.md
@@ -20,15 +20,17 @@ Prebuilt Tabler Components for Async HTML Rendering in Vapor
 
 ## Local Demos
 #### 🔥 Tablers Demo Website
-- Running the `Demo` target within Xcode
-- executing `swift run Demo`
+- Run the `Demo` target within Xcode
+- Or execute `swift run Demo`
 
 #### ✅ A Todo Demo
-The only thing missing from Vapor's awesome Todo example is a UI to interact with your fancy new API!
-- Running the `Todo` target within Xcode
-- executing `swift run Todo`
+The only thing missing from [Vapor's awesome Todo example](https://github.com/vapor/template-fluent-postgres) is a UI to interact with your fancy new API!
+- Make sure your Postgres (or DB of choice) server is up, running and reachable
+- Run the `Todo` target within Xcode
+- Or execute `swift run Todo` 
 
 > [!WARNING] 
+> Before running any of the demos or deploying your own app...
 > You need to create a `Public` dir in your apps working directory with Tablers [`static`](https://github.com/tabler/tabler/tree/dev/demo/static) and [`dist`](https://github.com/tabler/tabler/tree/dev/dist) assets with the following structure
 > ``` bash
 > ├── Public

--- a/README.md
+++ b/README.md
@@ -18,10 +18,15 @@ Prebuilt Tabler Components for Async HTML Rendering in Vapor
 
 ![VPT-Home](https://github.com/btoms20/AsyncPlotTabler/assets/32753167/c06128fb-48bc-43a6-94fc-ec9f73aa7d7d)
 
-> [!TIP]
-> You can run this same demo locally by cloning this repo and either
->  - Running the `Demo` target within Xcode
->  - executing `swift run Demo serve`
+## Local Demos
+#### 🔥 Tablers Demo Website
+- Running the `Demo` target within Xcode
+- executing `swift run Demo`
+
+#### ✅ A Todo Demo
+The only thing missing from Vapor's awesome Todo example is a UI to interact with your fancy new API!
+- Running the `Todo` target within Xcode
+- executing `swift run Todo`
 
 > [!WARNING] 
 > You need to create a `Public` dir in your apps working directory with Tablers [`static`](https://github.com/tabler/tabler/tree/dev/demo/static) and [`dist`](https://github.com/tabler/tabler/tree/dev/dist) assets with the following structure

--- a/Sources/Todo/Controllers/TodoController.swift
+++ b/Sources/Todo/Controllers/TodoController.swift
@@ -1,0 +1,90 @@
+import Fluent
+import Vapor
+import AsyncPlotTabler
+
+struct TodoController: RouteCollection {
+    static let root:String = "/todos"
+    
+    func boot(routes: RoutesBuilder) throws {
+        let todos = routes.grouped("todos")
+        todos.get(use: index)
+        todos.post(use: create)
+        todos.group(":todoID") { todo in
+            todo.get("delete", use: delete)
+            todo.get("toggle", use: toggle)
+        }
+    }
+
+    /// This is the main page of our Demo containing the Todo List
+    func index(req: Request) async throws -> Response {
+        // Fetch our Todo's from the database
+        let todos = try await Todo.query(on: req.db).all()
+        // Render the TodoPage with the Todo's
+        return await Response(
+            component: TodoPage(todos: todos)
+        )
+    }
+    
+    /// This route attempts to create a new `Todo` given valid POST data containing a `title`
+    func create(req: Request) async throws -> Response {
+        do {
+            let ct = try req.decodeAndValidate(Todo.Create.self)
+            let todo = Todo(title: ct.title, done: false)
+            try await todo.save(on: req.db)
+        } catch {
+            // If the error was due to an invalid Todo.Create object, then pass the error / feedback back along to the user.
+            if let validationError = error as? ValidationsError {
+                // Fetch our Todo's from the database
+                let todos = try await Todo.query(on: req.db).all()
+                // Render the TodoPage with the Todo's and Error Feedback
+                return await Response(
+                    component: TodoPage(todos: todos, feedback: validationError.description)
+                )
+            }
+        }
+        return req.redirect(to: TodoController.root)
+    }
+
+    /// This route deletes a `Todo` based on the `ID` encoded in the URL
+    func delete(req: Request) async throws -> Response {
+        guard let todo = try await Todo.find(req.parameters.get("todoID"), on: req.db) else {
+            throw Abort(.notFound)
+        }
+        try await todo.delete(force: true, on: req.db)
+        return req.redirect(to: TodoController.root)
+    }
+    
+    /// This route simply toggles the Todo's `done` value based on the `ID` encoded in the URL
+    func toggle(req: Request) async throws -> Response {
+        guard let todo = try await Todo.find(req.parameters.get("todoID"), on: req.db) else {
+            throw Abort(.notFound)
+        }
+        todo.done.toggle()
+        try await todo.update(on: req.db)
+        return req.redirect(to: TodoController.root)
+    }
+}
+
+extension Request {
+    /// A helper method that both decodes a `Content` struct and validates it when it conforms to the `Validatable` protocol
+    public func decodeAndValidate<C: Content>(_: C.Type) throws -> C {
+        if let V = C.self as? Validatable.Type { try V.validate(content: self) }
+        return try self.content.decode(C.self)
+    }
+}
+
+extension Response {
+    public convenience init(
+        status: HTTPResponseStatus = .ok,
+        version: HTTPVersion = .init(major: 1, minor: 1),
+        headers: HTTPHeaders = .init(),
+        component: Component = EmptyComponent()
+    ) async {
+        self.init(
+            status: status,
+            version: version,
+            headers: headers,
+            body: .init(string: await component.renderInWrappedHTMLBody())
+        )
+    }
+}

--- a/Sources/Todo/Migrations/CreateTodo.swift
+++ b/Sources/Todo/Migrations/CreateTodo.swift
@@ -1,0 +1,20 @@
+import Fluent
+
+struct CreateTodo: AsyncMigration {
+    func prepare(on database: Database) async throws {
+        try await database.schema("todos")
+            .id()
+            .field("title", .string, .required)
+            .field("done", .bool, .required)
+            
+            // Additional meta data
+            .field("created_at", .datetime, .required)
+            .field("updated_at", .datetime)
+            .field("deleted_at", .datetime)
+            .create()
+    }
+
+    func revert(on database: Database) async throws {
+        try await database.schema("todos").delete()
+    }
+}

--- a/Sources/Todo/Models/Todo.swift
+++ b/Sources/Todo/Models/Todo.swift
@@ -1,0 +1,87 @@
+import Fluent
+import Vapor
+
+final class Todo: Model, Content {
+    static let schema = "todos"
+    
+    @ID(key: .id)
+    var id: UUID?
+
+    @Timestamp(key: "created_at", on: .create)
+    var createdAt:Date?
+    
+    @Timestamp(key: "updated_at", on: .update)
+    var updatedAt:Date?
+    
+    @Timestamp(key: "deleted_at", on: .delete)
+    var deletedAt:Date?
+    
+    @Field(key: "title")
+    var title: String
+    
+    @Field(key: "done")
+    var done: Bool
+    
+    init() { }
+
+    init(id: UUID? = nil, title: String, done: Bool = false) {
+        self.id = id
+        self.title = title
+        self.done = done
+    }
+}
+
+extension Todo {
+    /// A struct used for Creating a new `Todo` Item
+    /// - Note: We conform to `Validatable` to verify user input and to provide feedback to the user when invalid input is provided (such as an emtpy `title` string)
+    /// - Note: A `ValidationsError` provides human readable feedback, which we pass along to the user in the ``TodoController/create(req:)`` route
+    struct Create:Content, Validatable {
+        let title:String
+        
+        /// We can use the `Validatable` protocol to ensure that new `Todo` items have a `title` that is more than one letter and less than 51 letters.
+        static func validations(_ validations: inout Validations) {
+            // Ensure the title is between 2 and 50 chars
+            validations.add("title", as: String.self, is: .count(2...50))
+            
+            // If we hate joy and wanted to prevent emojis we could enforce an only .ascii characters rule
+            //validations.add("title", as: String.self, is: .ascii)
+        }
+    }
+}
+
+extension Array where Element == Todo {
+    /// Sorts an Array of Todo items by whether or not they're marked done
+    var sortByDone:Array<Todo> {
+        self.sorted { lhs, rhs in
+            switch (lhs.done, rhs.done) {
+            case (false, true):
+                return true
+            default:
+                return false
+            }
+        }
+    }
+    
+    /// Splits an Array of Todos into two parts, one sequence that's marked done and one sequence that isn't
+    var sortAndGroup:[(Bool, Array<Todo>.SubSequence)] {
+        self.sortByDone.chunked(on: { $0.done })
+    }
+}
+
+extension ArraySlice where Element == Todo {
+    /// Sorts an Array of Todo elements by their creation date
+    var sortedByCreationDate:Array<Todo> {
+        self.sorted { lhs, rhs in
+            switch (lhs.createdAt, rhs.createdAt) {
+            case ( .some(let l), .some(let r) ):
+                return l < r
+            case (.none, .some):
+                return false
+            case (.some, .none):
+                return true
+            default:
+                return true
+            }
+        }
+    }
+}

--- a/Sources/Todo/Views/TodoPage.swift
+++ b/Sources/Todo/Views/TodoPage.swift
@@ -1,0 +1,117 @@
+import AsyncPlotTabler
+
+/// A page with a Todo List that can be interacted with
+struct TodoPage: Component {
+    /// A list of Todo items to display
+    let todos:[Todo]
+    /// Feedback to give to the user in the form of an error
+    let feedback:String?
+    
+    /// Initializes a new Todo Page with a Header, NavBar and a Todo List
+    /// - Parameters:
+    ///   - todos: An array of Todo items to render / display to the user
+    ///   - feedback: An error to display to the user (useful for Form validation feedback)
+    public init(todos: [Todo], feedback: String? = nil) {
+        self.todos = todos
+        self.feedback = feedback
+    }
+    
+    func body() async -> Component {
+        // Because we only have one page in our entire website, we'll configure the Site here
+        // Normally you'd configure the Site elsewhere and `inject` each Page into it as the user navigates throughout the website
+        await Site(
+            // A Site has a NavBar that can be configured
+            header: NavBar(
+                // The Brand is a great place for your Websites name and Logo
+                brand: .init(title: "Todo List Demo"),
+                // Routes takes an array of RouteItems linking to various pages in your Website
+                routes: [
+                    .init(title: "Home", url: "/todos", icon: .home, active: true),
+                ],
+                // This determines if the Notification bell is present on the right hand side of the NavBar
+                notificationsEnabled: false,
+                // This determines if the search box is present
+                searchEnabled: false
+            ),
+            // The actual contents of your Page (everything below the navbar
+            page: Page(header: .init(header: "TODOs"), content: {
+                // Similar to a VStack is SwiftUI, a CardVStack makes it easy to stack/position multiple cards
+                await CardVStack {
+                    // A Card is a styled Div that makes it easy to format content
+                    // Every Card can have a Header, Body and Footer section
+                    await Card(
+                        // Let's give the card a title
+                        header: .init({
+                            Card.Title("Your Todo List")
+                        }),
+                        // In the body of the card we'll display each of our Todo Items
+                        body: .raw({
+                            // We can place the Todo items in a ListGroup to give them a nicer look and embed them in a scroll view
+                            // ListGroups support grouping your ListItems into groups with titles, lets do that here
+                            // We'll group the Todo's into two groups `Completed` and `Outstanding`
+                            await Plot.Form.ListGroup(theme: .flush, scrollable: true, hoverable: true, groupedItems: todos.sortAndGroup.asyncMap { todoGroup in
+                                await .init(label: todoGroup.0 ? "Completed" : "Outstanding", items: todoGroup.1.sortedByCreationDate.asyncCompactMap { todo in
+                                    await TodoListItem(todo: todo)
+                                })
+                            })
+                        }),
+                        // The footer of this card is a great place to add a TextField and a `Create Todo` button for todo creation
+                        footer: .init({
+                            // We wrap the TextField in a Form to capture the user input
+                            Form(url: "/todos", method: .post, contentType: .multipartData, enableValidation: false) {
+                                // Placing our TextField and Button in an InputGroup styles them as one feature
+                                await Plot.Form.InputGroup {
+                                    Plot.Form.Textfield(name: "title", placeholder: "New todo item...")
+                                        .class(feedback == nil ? "" : "is-invalid")
+                                    ButtonLink(type: .submit, text: "Create Todo")
+                                }
+                                .class("w-100")
+                                
+                                // If we have feedback for the user... display it here
+                                if let feedback {
+                                    Span {
+                                        SVGIcon(icon: .exclamation_circle, color: .red, size: .xs)
+                                            .margin(.trailing(2))
+                                        Text("\(feedback)")
+                                    }
+                                    .textColor(.red)
+                                    .fontWeight(.light)
+                                }
+                            }
+                        })
+                    )
+                }
+            })
+        )
+    }
+    
+    /// An individual Todo Item's Cell
+    private func TodoListItem(todo: Todo) async -> Form.ListGroup.Item? {
+        // Ensure this Todo Item has an ID
+        guard let id = todo.id else { return nil }
+        // Construct the rootURL for this Todo Item
+        let rootURL = "/todos/\(id.uuidString)"
+        // Let's contruct and return the ListGroup.Item
+        return await Form.ListGroup.Item(link: "#") {
+            await Row(alignItemsCenter: true) {
+                // One segment for the Checkbox, Title and Date Created
+                await Column {
+                    // Lets wrap each Todo item cell in a Form so that we can respond to Checkbox events
+                    Plot.Form(url: "\(rootURL)/toggle", method: .get, contentType: .none, enableValidation: false) {
+                        await Plot.Form.Checkbox(name: "todo-\(id.uuidString)", checked: todo.done, required: false, triggersFormOnCheck: true, label: {
+                            Text(todo.title)
+                        }, description: {
+                            Text("\(todo.createdAt?.formatted() ?? "\(id.uuidString)")")
+                        })
+                    }
+                }
+                // And another segment to hold our Delete button
+                await Column {
+                    Link(url: "\(rootURL)/delete") { SVGIcon(icon: .trash, color: .red) }
+                        .class("list-group-item-actions")
+                }
+                .class("col-auto")
+            }
+        }
+    }
+}

--- a/Sources/Todo/configure.swift
+++ b/Sources/Todo/configure.swift
@@ -1,0 +1,26 @@
+import NIOSSL
+import Fluent
+import FluentPostgresDriver
+import Vapor
+
+// configures your application
+public func configure(_ app: Application) async throws {
+    // uncomment to serve files from /Public folder
+    app.middleware.use(FileMiddleware(publicDirectory: app.directory.publicDirectory))
+
+    // configure our postgres database
+    app.databases.use(DatabaseConfigurationFactory.postgres(configuration: .init(
+        hostname: Environment.get("DATABASE_HOST") ?? "localhost",
+        port: Environment.get("DATABASE_PORT").flatMap(Int.init(_:)) ?? SQLPostgresConfiguration.ianaPortNumber,
+        username: Environment.get("DATABASE_USERNAME") ?? "vapor_username",
+        password: Environment.get("DATABASE_PASSWORD") ?? "vapor_password",
+        database: Environment.get("DATABASE_NAME") ?? "vapor_database",
+        tls: .prefer(try .init(configuration: .clientDefault)))
+    ), as: .psql)
+
+    // add the Todo model to the database
+    app.migrations.add(CreateTodo())
+
+    // register routes
+    try routes(app)
+}

--- a/Sources/Todo/entrypoint.swift
+++ b/Sources/Todo/entrypoint.swift
@@ -1,0 +1,21 @@
+import Vapor
+import Logging
+
+@main
+enum Entrypoint {
+    static func main() async throws {
+        var env = try Environment.detect()
+        try LoggingSystem.bootstrap(from: &env)
+        
+        let app = Application(env)
+        defer { app.shutdown() }
+        
+        do {
+            try await configure(app)
+        } catch {
+            app.logger.report(error: error)
+            throw error
+        }
+        try await app.execute()
+    }
+}

--- a/Sources/Todo/routes.swift
+++ b/Sources/Todo/routes.swift
@@ -1,0 +1,6 @@
+import Fluent
+import Vapor
+
+func routes(_ app: Application) throws {
+    try app.register(collection: TodoController())
+}


### PR DESCRIPTION
This PR adds a Todo list demo that builds off of Vapor's basic Todo example when creating a new project using Fluent.

Starting with the base Todo example we made the following changes...
- Extended the Todo Model with createdAt, updatedAt and deletedAt params for some extra metadata
- Created a few routes to support editing Todo's (create, toggle completed and delete)
- Implemented a Site and Page component that displays our Todo List
- Implemented the Todo List itself

If you have a Postgres database set up, running and working with Vapors Fluent Todo demo, then running this demo should work without issue.